### PR TITLE
Fix search configuration for Solr and Sitecore 8.2 schema changes

### DIFF
--- a/Source/TokenManager/Tokens.config
+++ b/Source/TokenManager/Tokens.config
@@ -47,7 +47,27 @@
 					<fields hint="raw:AddComputedIndexField">
 						<field fieldName="_tokens" storageType="yes" indexType="untokenized">TokenManager.ContentSearch.Tokens, TokenManager</field>
 					</fields>
+
+					<!-- for 8.2+ -->
+					<documentOptions>
+						<fields hint="raw:AddComputedIndexField">
+							<field fieldName="_tokens" storageType="yes" indexType="untokenized">TokenManager.ContentSearch.Tokens, TokenManager</field>
+						</fields>
+					</documentOptions>
 				</defaultLuceneIndexConfiguration>
+
+				<defaultSolrIndexConfiguration>
+					<fields hint="raw:AddComputedIndexField">
+						<field fieldName="_tokens" storageType="yes" indexType="untokenized">TokenManager.ContentSearch.Tokens, TokenManager</field>
+					</fields>
+
+					<!-- for 8.2+ -->
+					<documentOptions>
+						<fields hint="raw:AddComputedIndexField">
+							<field fieldName="_tokens" storageType="yes" indexType="untokenized">TokenManager.ContentSearch.Tokens, TokenManager</field>
+						</fields>
+					</documentOptions>
+				</defaultSolrIndexConfiguration>
 			</indexConfigurations>
 		</contentSearch>
 	</sitecore>


### PR DESCRIPTION
* 7.x-8.1 compatibility with computed index field registration
* 8.2+ compatibility with computed index field registration
* Register Solr index fields as well as Lucene