### PR TITLE
Fix build when VS2017 is the only thing installed

### DIFF
--- a/Build/PackageNuGet.ps1
+++ b/Build/PackageNuGet.ps1
@@ -2,8 +2,27 @@ param($scriptRoot)
 
 $ErrorActionPreference = "Stop"
 
-$programFilesx86 = ${Env:ProgramFiles(x86)}
-$msBuild = "$programFilesx86\MSBuild\14.0\bin\msbuild.exe"
+function Resolve-MsBuild {
+	$msb2017 = Resolve-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\*\*\MSBuild\*\bin\msbuild.exe" -ErrorAction SilentlyContinue
+	if($msb2017) {
+		Write-Host "Found MSBuild 2017 (or later)."
+		Write-Host $msb2017
+		return $msb2017
+	}
+
+	$msBuild2015 = "${env:ProgramFiles(x86)}\MSBuild\14.0\bin\msbuild.exe"
+
+	if(-not (Test-Path $msBuild2015)) {
+		throw 'Could not find MSBuild 2015 or later.'
+	}
+
+	Write-Host "Found MSBuild 2015."
+	Write-Host $msBuild2015
+
+	return $msBuild2015
+}
+
+$msBuild = Resolve-MsBuild
 $nuGet = "$scriptRoot..\tools\NuGet.exe"
 $solution = "$scriptRoot\..\TokenManager.sln"
 


### PR DESCRIPTION
VS2017 puts msbuild elsewhere from VS2015. This patch fixes your NuGet build script when 2015 is not installed.