### PR TITLE
Allow non-AutoToken RTE Buttons to be kept

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ These tokens are designed primarily for authors.  They take more development eff
 
 In practice these tokens have not proven to be particularly useful, but they still exist for now.  You can read more about them [here](https://jeffdarchuk.com/2015/10/26/sitecore-tokenmanager/)
 
+If you are using these tokens and don't want the TokenManager to delete and restore the RTE buttons on startup, simply protect the button items and the TokenManager won't recreate them.
+
 + Basic Token
 	* A simple token that injects content from an RTE.
 + Rendering Token

--- a/Source/TokenManager/Management/DefaultTokenKeeperService.cs
+++ b/Source/TokenManager/Management/DefaultTokenKeeperService.cs
@@ -448,7 +448,11 @@ namespace TokenManager.Management
 				foreach (Item tokenButton in db.DataManager.DataEngine
 					.GetItem(new ID(Constants.Core.RteParent), LanguageManager.DefaultLanguage, Sitecore.Data.Version.Latest).Axes
 					.GetDescendants().Where(x =>
-						x["Click"].StartsWith("TokenSelector") && x.TemplateID.ToString() == "{3C8BD8A1-280B-4278-BB8B-21FA3B87AF0F}"))
+						x["Click"].StartsWith("TokenSelector")
+						&& x.TemplateID.ToString() == "{3C8BD8A1-280B-4278-BB8B-21FA3B87AF0F}"
+						&& x[FieldIDs.ReadOnly] != "1" // allow to protect non autotoken buttons and keep them
+						)
+					)
 				{
 					if (!ValidTokenButtons.Contains(tokenButton.ID))
 					{


### PR DESCRIPTION
allows fixing https://github.com/JeffDarchuk/SCTokenManager/issues/32 by protecting the items